### PR TITLE
fix: json rpc update context

### DIFF
--- a/app/src/api/dataSource/ClientApiDataSource.ts
+++ b/app/src/api/dataSource/ClientApiDataSource.ts
@@ -6,8 +6,8 @@ import {
   WsSubscriptionsClient,
   createAuthHeader,
 } from '@calimero-is-near/calimero-p2p-sdk';
-import { getContextId, getRpcPath } from '../../utils/env';
-import { getAppEndpointKey, getExecutorPublicKey } from '../../utils/storage';
+import { getRpcPath } from '../../utils/env';
+import { getAppEndpointKey, getContextId, getExecutorPublicKey } from '../../utils/storage';
 import {
   ClientApi,
   ClientMethod,

--- a/app/src/api/dataSource/ClientApiDataSource.ts
+++ b/app/src/api/dataSource/ClientApiDataSource.ts
@@ -7,7 +7,11 @@ import {
   createAuthHeader,
 } from '@calimero-is-near/calimero-p2p-sdk';
 import { getRpcPath } from '../../utils/env';
-import { getAppEndpointKey, getContextId, getExecutorPublicKey } from '../../utils/storage';
+import {
+  getAppEndpointKey,
+  getContextId,
+  getExecutorPublicKey,
+} from '../../utils/storage';
 import {
   ClientApi,
   ClientMethod,


### PR DESCRIPTION
# fix: json rpc update context

## Summary:
Json rpc requests were fetching context id from environment variables and not from storage